### PR TITLE
Use relative paths for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  base: '/NOBLEDRAGON/',
+  base: './',
   plugins: [react()],
 });


### PR DESCRIPTION
## Summary
- set Vite base to `./` for repository-safe relative URLs
- switch index.html asset links to relative paths

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`
- `npm run deploy` *(fails: Failed to get remote.origin.url)*

------
